### PR TITLE
Set IMAGE_NAME during initialisation

### DIFF
--- a/base
+++ b/base
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -x
+set +x
 set +e
 
 #


### PR DESCRIPTION
I'm testing a new set of build scripts locally and running into shell syntax errors (see #6 and #7) with docker commands.

Turns out this is because the `$IMAGE_NAME` variable is under an `if [-f file]` and gets skipped in non-clean builds.

Also `$REPO` doesn't seem to get used anywhere?
