### PR TITLE
Fix: not aborting in case of error

### DIFF
--- a/base
+++ b/base
@@ -42,6 +42,22 @@ build_init () {
 	IMAGE_NAME="${NAME}-${GIT_BRANCH}-${VERSION}"
 }
 
+#
+# Check if a given docker container failed. If so, clean up and bail out.
+#
+bailout_on_failure () {
+        RC=$(docker $DOCKER_OPTS wait "$1")
+	if [ $RC -ne 0 ]; then
+	    echo "Build returned nonzero exit status, bailing out."
+	    # Fix access privileges
+	    docker $DOCKER_OPTS run --rm \
+	        -v ${PWD}/cache:/src:rw \
+		"$DOCKER_REGISTRY/engineering/haskell" \
+		"/bin/bash" -c "chown -R $USER /src"
+	    exit 1
+	fi
+}
+
 
 #
 # Install a base system
@@ -74,16 +90,7 @@ baseline () {
 		-v ${PWD}/cache:/src:rw \
 		"$DOCKER_REGISTRY/engineering/haskell" \
 		"/bin/bash" -c "/src/baseline && chown -R $USER /src"
-	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
-	if [ $RC -ne 0 ]; then
-	    echo "Build returned nonzero exit status, bailing out."
-	    # Fix access privileges
-	    docker $DOCKER_OPTS run --rm \
-	        -v ${PWD}/cache:/src:rw \
-		"$DOCKER_REGISTRY/engineering/haskell" \
-		"/bin/bash" -c "chown -R $USER /src"
-	    exit 1
-	fi
+	bailout_on_failure "$IMAGE_NAME"
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:baseline"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"
 
@@ -104,16 +111,7 @@ objects () {
 	        $DOCKER_REGISTRY/engineering/${NAME}:baseline \
 	        "/bin/bash" -c "/src/objects && chown -R $USER /src"
 
-	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
-	if [ $RC -ne 0 ]; then
-	    echo "Build returned nonzero exit status, bailing out."
-	    # Fix access privileges
-	    docker $DOCKER_OPTS run --rm \
-	        -v ${PWD}/cache:/src:rw \
-		"$DOCKER_REGISTRY/engineering/haskell" \
-		"/bin/bash" -c "chown -R $USER /src"
-	    exit 1
-	fi
+	bailout_on_failure "$IMAGE_NAME"
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:objects"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"
 
@@ -134,15 +132,7 @@ release () {
 	       $DOCKER_REGISTRY/afcowie/debian:jessie \
 	       "/bin/bash" -c "/src/release && chown -R $USER /src"
 	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
-	if [ $RC -ne 0 ]; then
-	    echo "Build returned nonzero exit status, bailing out."
-	    # Fix access privileges
-	    docker $DOCKER_OPTS run --rm \
-	        -v ${PWD}/cache:/src:rw \
-		"$DOCKER_REGISTRY/engineering/haskell" \
-		"/bin/bash" -c "chown -R $USER /src"
-		exit 1
-	fi
+	bailout_on_failure "$IMAGE_NAME"
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:${VERSION}"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"
 	touch cache/stamp/release

--- a/base
+++ b/base
@@ -131,7 +131,6 @@ release () {
 	       -v ${PWD}/cache:/src:rw \
 	       $DOCKER_REGISTRY/afcowie/debian:jessie \
 	       "/bin/bash" -c "/src/release && chown -R $USER /src"
-	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
 	bailout_on_failure "$IMAGE_NAME"
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:${VERSION}"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"

--- a/base
+++ b/base
@@ -55,6 +55,7 @@ initialize () {
 
 	rsync -a src/ cache
 
+	docker $DOCKER_OPTS pull $DOCKER_REGISTRY/afcowie/debian:jessie
 	docker $DOCKER_OPTS pull $DOCKER_REGISTRY/engineering/haskell:latest
 	touch cache/stamp/initialize
 }

--- a/base
+++ b/base
@@ -55,7 +55,6 @@ initialize () {
 
 	rsync -a src/ cache
 
-	docker $DOCKER_OPTS pull $DOCKER_REGISTRY/afcowie/debian:jessie
 	docker $DOCKER_OPTS pull $DOCKER_REGISTRY/engineering/haskell:latest
 	touch cache/stamp/initialize
 }
@@ -73,10 +72,16 @@ baseline () {
 	docker $DOCKER_OPTS run --name="$IMAGE_NAME" -t \
 		-v ${PWD}/cache:/src:rw \
 		"$DOCKER_REGISTRY/engineering/haskell" \
-		"/bin/bash" -c "/src/baseline ; chown -R $USER /src"
+		"/bin/bash" -c "/src/baseline && chown -R $USER /src"
 	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
 	if [ $RC -ne 0 ]; then
-		echo "Build returned nonzero exit status, bailing out."
+	    echo "Build returned nonzero exit status, bailing out."
+	    # Fix access privileges
+	    docker $DOCKER_OPTS run --rm \
+	        -v ${PWD}/cache:/src:rw \
+		"$DOCKER_REGISTRY/engineering/haskell" \
+		"/bin/bash" -c "chown -R $USER /src"
+	    exit 1
 	fi
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:baseline"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"
@@ -96,11 +101,17 @@ objects () {
 	docker $DOCKER_OPTS run --name="$IMAGE_NAME" -t \
 	        -v ${PWD}/cache:/src:rw \
 	        $DOCKER_REGISTRY/engineering/${NAME}:baseline \
-	        "/bin/bash" -c "/src/objects ; chown -R $USER /src"
+	        "/bin/bash" -c "/src/objects && chown -R $USER /src"
 
 	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
 	if [ $RC -ne 0 ]; then
-		echo "Build returned nonzero exit status, bailing out."
+	    echo "Build returned nonzero exit status, bailing out."
+	    # Fix access privileges
+	    docker $DOCKER_OPTS run --rm \
+	        -v ${PWD}/cache:/src:rw \
+		"$DOCKER_REGISTRY/engineering/haskell" \
+		"/bin/bash" -c "chown -R $USER /src"
+	    exit 1
 	fi
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:objects"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"
@@ -120,10 +131,16 @@ release () {
 	docker $DOCKER_OPTS run --name="$IMAGE_NAME" -t \
 	       -v ${PWD}/cache:/src:rw \
 	       $DOCKER_REGISTRY/afcowie/debian:jessie \
-	       "/bin/bash" -c "/src/release ; chown -R $USER /src"
+	       "/bin/bash" -c "/src/release && chown -R $USER /src"
 	RC=$(docker $DOCKER_OPTS wait "$IMAGE_NAME")
 	if [ $RC -ne 0 ]; then
-		echo "Build returned nonzero exit status, bailing out."
+	    echo "Build returned nonzero exit status, bailing out."
+	    # Fix access privileges
+	    docker $DOCKER_OPTS run --rm \
+	        -v ${PWD}/cache:/src:rw \
+		"$DOCKER_REGISTRY/engineering/haskell" \
+		"/bin/bash" -c "chown -R $USER /src"
+		exit 1
 	fi
 	docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:${VERSION}"
 	docker $DOCKER_OPTS rm "$IMAGE_NAME"


### PR DESCRIPTION
The build wasn't aborting properly in case of failure. This led to deployment images without any binaries.